### PR TITLE
ENH exclude "*descriptions.md" pattern on build

### DIFF
--- a/brainhack_book/_config.yml
+++ b/brainhack_book/_config.yml
@@ -9,14 +9,15 @@ title                       : "Everything Brainhack: past, present and future"  
 author                      :  The Brainhack community  # The author of the book
 copyright                   : "2020"  # Copyright year to be placed in the footer
 logo                        : "static/brainhack-logo.png"  # A path to the book logo
-exclude_patterns            : []  # Patterns to skip when building the book. Can be glob-style (e.g. "*skip.ipynb")
+exclude_patterns            : "*descriptions.md"  # Patterns to skip when building the book. Can be glob-style (e.g. "*skip.ipynb")
 
 #######################################################################################
 # Execution settings
 execute:
   execute_notebooks         : auto  # Whether to execute notebooks at build time. Must be one of ("auto", "force", "cache", "off")
   cache                     : ""  # A path to the jupyter cache that will be used to store execution artifacs. Defaults to `_build/.jupyter_cache/`
-  exclude_patterns          : []  # A list of patterns to *skip* in execution (e.g. a notebook that takes a really long time)
+  exclude_patterns          : 
+    - "*descriptions.md"  # A list of patterns to *skip* in execution (e.g. a notebook that takes a really long time)
 
 #######################################################################################
 # HTML-specific settings


### PR DESCRIPTION
I think this glob style solution in `_config.yml` should exclude all of the `*descriptions.md` files during the Jupyter Book build